### PR TITLE
Feature/swagger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,20 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+
+		<!-- Swagger !-->
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-boot-starter</artifactId>
+			<version>3.0.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger-ui</artifactId>
+			<version>3.0.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/mercadolibro/config/SwaggerConfig.java
+++ b/src/main/java/com/mercadolibro/config/SwaggerConfig.java
@@ -1,0 +1,30 @@
+package com.mercadolibro.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+
+@Configuration
+public class SwaggerConfig {
+    private final String controllersBasePackage = "com.mercadolibro.controllers";
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage(controllersBasePackage))
+                .build().apiInfo(apiInfo());
+    }
+
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title("MercadoLibro")
+                .description("API for MercadoLibro")
+                .version("1.0")
+                .build();
+    }
+}

--- a/src/main/java/com/mercadolibro/controllers/HealtChectkController.java
+++ b/src/main/java/com/mercadolibro/controllers/HealtChectkController.java
@@ -2,6 +2,7 @@ package com.mercadolibro.controllers;
 
 import java.util.List;
 
+import io.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,12 +23,13 @@ public class HealtChectkController {
 	@Autowired
 	private TestService testService;
 
-
+	@ApiOperation(value = "Health check", notes = "Health check")
 	@GetMapping("/ping")
 	public ResponseEntity<String> healtCheck() {
 		return ResponseEntity.status(HttpStatus.OK).body("pong");
 	}
-	
+
+	@ApiOperation(value = "Test list", notes = "This is a test service")
 	@GetMapping("/test")
 	public ResponseEntity<List<TestDTO>> listTest() {
 		return ResponseEntity.status(HttpStatus.OK).body(testService.getAll().get());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,9 @@ spring:
     username: ${DB_USERNAME:root}
     url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:booksdb}?
     driver-class-name: com.mysql.cj.jdbc.Driver
+  mvc:
+    pathmatch:
+      matching-strategy: ANT_PATH_MATCHER
 server:
   error:
     include-stacktrace: never

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,20 +3,20 @@ spring:
     show-sql: true
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: true
   application:
-    name: mercadolibro-service
+    name: ${APP_NAME:mercadolibro-service}
   flyway:
     baseline-on-migrate: 'false'
   datasource:
-    password: root
-    username: root
-    url: jdbc:mysql://localhost:3306/booksdb?autoReconnect=true&useSSL=false
+    password: ${DB_PASSWORD:root}
+    username: ${DB_USERNAME:root}
+    url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:booksdb}?
+    driver-class-name: com.mysql.cj.jdbc.Driver
 server:
   error:
     include-stacktrace: never
-  port: 8080
+  port: ${SERVER_PORT:8080}
 logging:
   level:
     org:


### PR DESCRIPTION
### Resumen
Se implementó la configuración básica de swagger. También se realizaron cambios a la configuración del proyecto para que se puedan obtener las credenciales de la base de datos, el puerto del servidor y el nombre del servicio a través de variables de entorno. También se eliminó una configuración con respecto al dialecto sql que generaba problemas a la hora de cargar la base de datos. 

Relacionado con:
 [ML-233](https://mercado-libro.atlassian.net/browse/ML-233?atlOrigin=eyJpIjoiY2UwN2M2NzljMzE5NDk0Yzk5Y2Y1ZDkwZDllMTMzMGMiLCJwIjoiaiJ9)
[ML-234](https://mercado-libro.atlassian.net/browse/ML-234?atlOrigin=eyJpIjoiOTAzOGI4NDJjN2Q0NGU1NjgyNzFhYzVmMjZlYTBiMGMiLCJwIjoiaiJ9)
[ML-235](https://mercado-libro.atlassian.net/browse/ML-235?atlOrigin=eyJpIjoiNzEyMzBmMjQ4ODk0NDcwNzgyM2I0YThlNmJhY2MwN2EiLCJwIjoiaiJ9)
[ML-236](https://mercado-libro.atlassian.net/browse/ML-236?atlOrigin=eyJpIjoiZGE4ZjIxYzRlYTlhNDVmNTlmMDA4NTAxZGUwNjdkNjUiLCJwIjoiaiJ9)
[ML-237](https://mercado-libro.atlassian.net/browse/ML-237?atlOrigin=eyJpIjoiYTg2NmRmMGJhZTJjNDhmYmI2M2I5Nzc0YjhiZmU0ZTgiLCJwIjoiaiJ9)
[ML-238](https://mercado-libro.atlassian.net/browse/ML-238?atlOrigin=eyJpIjoiYmEyMjBmZjFhOGNlNDI3NWFiNTY5OTA0NDcxYjIwZDMiLCJwIjoiaiJ9)
[ML-239](https://mercado-libro.atlassian.net/browse/ML-239?atlOrigin=eyJpIjoiMGEzZDE5MGNmNTIxNDY1NThjYmZkNDFjODhlZDFiZDEiLCJwIjoiaiJ9)

## Swagger
Se añadió la librería springfox, para ver anotaciones para documentar mejor los endpoints generados se puede consultar: [wiki anotaciones swagger](https://github.com/swagger-api/swagger-core/wiki/Annotations)

### Uso
Para acceder a la documentación se debe ingresar a [/swagger-ui/index.html#/](/swagger-ui/index.html#/)

![image](https://github.com/rrrrho/mercado-libro-backend/assets/62969028/871ba5b6-9845-45f4-8b41-daba75294381)


### Dependencias añadidas

```XML
		<dependency>
			<groupId>io.springfox</groupId>
			<artifactId>springfox-boot-starter</artifactId>
			<version>3.0.0</version>
		</dependency>

		<dependency>
			<groupId>io.springfox</groupId>
			<artifactId>springfox-swagger-ui</artifactId>
			<version>3.0.0</version>
		</dependency>
```

## Configuración del proyecto:
Se eliminó del application.yml la propiedad ```dialect: org.hibernate.dialect.PostgreSQLDialect``` que generaba conflictos con mysql, este conflicto no solamente me ocurrió a mí sino que fue reportado por otros compañeros.

Se modificaron las siguientes propiedades

```YML
    name: ${APP_NAME:mercadolibro-service}
    url: jdbc:mysql://localhost:3306/booksdb?autoReconnect=true&useSSL=false
    password: ${DB_PASSWORD:root}
    username: ${DB_USERNAME:root}
    url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:booksdb}?
   matching-strategy: ANT_PATH_MATCHER
  port: ${SERVER_PORT:8080}
```
La propiedad matching-strategy es para que el swagger funcione correctamente. 

