### PR TITLE
Feature/Pull Request Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Resumen
+[Descripción general de los cambios realizados en el PR]
+
+Relacionado con:
+- [Enlaces a las tareas de Jira relacionadas]
+
+## Funcionamiento
+[Explicación del funcionamiento implementado]
+
+## Tipo de cambio
+[Eliminar las opciones que no sean relevantes]
+
+- [ ] Corrección de error (cambio que no rompe nada y resuelve un problema)
+- [ ] Nueva característica (cambio que no rompe nada y agrega funcionalidad)
+- [ ] Cambio disruptivo (corrección o característica que causaría que la funcionalidad existente no funcione como se esperaba)
+
+## Pruebas Unitarias
+[Descripción de las pruebas unitarias realizadas y los casos que abarcan]
+
+# Lista de verificación:
+
+- [ ] Mi código sigue las pautas de estilo de este proyecto
+- [ ] Este cambio requiere una actualización de la documentación
+- [ ] He realizado cambios correspondientes en la documentación


### PR DESCRIPTION
## Resumen
Fue añadido un template inicial para todos los PR que se creen en el repositorio.

## Funcionamiento
El funcionamiento se aplica automáticamente a través de Github creando el archivo `pull_request_template.md` dentro de la carpeta `.github`.

#### Screenshot del template añadido:
![Screenshot_16](https://github.com/jhavierc/mercado-libro-backend/assets/80919026/0f9d4a91-538c-44cb-bc30-6c2423701dff)