### PR TITLE
Feature/login

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,13 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
+
+		<!-- JWT !-->
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt</artifactId>
+			<version>0.9.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,12 @@
 			<artifactId>springfox-swagger-ui</artifactId>
 			<version>3.0.0</version>
 		</dependency>
+
+		<!-- Security !-->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/mercadolibro/config/SwaggerConfig.java
+++ b/src/main/java/com/mercadolibro/config/SwaggerConfig.java
@@ -5,8 +5,15 @@ import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.ApiKey;
+import springfox.documentation.service.HttpAuthenticationScheme;
+import springfox.documentation.service.VendorExtension;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 @Configuration
 public class SwaggerConfig {
@@ -14,10 +21,14 @@ public class SwaggerConfig {
 
     @Bean
     public Docket api() {
-        return new Docket(DocumentationType.SWAGGER_2)
+        return new Docket(DocumentationType.OAS_30)
                 .select()
                 .apis(RequestHandlerSelectors.basePackage(controllersBasePackage))
-                .build().apiInfo(apiInfo());
+                .build().apiInfo(apiInfo())
+                .securitySchemes(Collections.singletonList(HttpAuthenticationScheme
+                        .JWT_BEARER_BUILDER
+                        .name("JWT Token")
+                        .build()));
     }
 
     private ApiInfo apiInfo() {

--- a/src/main/java/com/mercadolibro/controller/AuthController.java
+++ b/src/main/java/com/mercadolibro/controller/AuthController.java
@@ -1,0 +1,61 @@
+package com.mercadolibro.controller;
+
+import com.mercadolibro.dto.AuthReq;
+import com.mercadolibro.dto.AuthResp;
+import com.mercadolibro.dto.UserDTO;
+import com.mercadolibro.exception.ResourceNotFoundException;
+import com.mercadolibro.service.UserService;
+import com.mercadolibro.util.JwtUtil;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.Authorization;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequestMapping("/api/auth")
+@CrossOrigin(origins = "*", methods = { RequestMethod.GET, RequestMethod.POST })
+public class AuthController {
+    private final AuthenticationManager authenticationManager;
+    private final UserService userService;
+    private final JwtUtil jwtUtil;
+
+    @Autowired
+    public AuthController(AuthenticationManager authenticationManager, UserService userService, JwtUtil jwtUtil) {
+        this.authenticationManager = authenticationManager;
+        this.userService = userService;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthResp> createToken(@RequestBody AuthReq request) throws ResourceNotFoundException {
+        try {
+            authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword()));
+            UserDetails userDetails = userService.loadUserByUsername(request.getEmail());
+            UserDTO user = userService.findByEmail(userDetails.getUsername());
+            String jwt = jwtUtil.generateToken(user);
+            return new ResponseEntity<>(new AuthResp(jwt, user), HttpStatus.OK);
+        }
+        catch (BadCredentialsException e) {
+            return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+        }
+    }
+
+    @GetMapping("/refresh")
+    @ApiOperation(value = "Refresh token", notes = "Returns the user", authorizations = {@Authorization(value = "JWT Token")})
+    public ResponseEntity<AuthResp> refreshToken(HttpServletRequest request) throws ResourceNotFoundException {
+        String token = request.getHeader("Authorization");
+        if (token == null ) return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+        String jwt = token.substring(7);
+        String email = jwtUtil.extractUsername(jwt);
+        UserDTO user = userService.findByEmail(email);
+        return new ResponseEntity<>(new AuthResp(jwt, user), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/mercadolibro/controller/UserController.java
+++ b/src/main/java/com/mercadolibro/controller/UserController.java
@@ -5,23 +5,30 @@ import com.mercadolibro.exception.ResourceNotFoundException;
 import com.mercadolibro.dto.UserDTO;
 import com.mercadolibro.dto.UserRegisterDTO;
 import com.mercadolibro.service.UserService;
+import com.mercadolibro.util.JwtUtil;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.v3.oas.annotations.headers.Header;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
 
 @RestController
 @RequestMapping("/api/user")
 @CrossOrigin(origins = "*", methods = { RequestMethod.GET, RequestMethod.POST })
 public class UserController {
     private final UserService userService;
+    private final JwtUtil jwtUtil;
 
     @Autowired
-    public UserController(UserService userService) {
+    public UserController(UserService userService, JwtUtil jwtUtil) {
         this.userService = userService;
+        this.jwtUtil = jwtUtil;
     }
 
     @PostMapping
@@ -37,5 +44,16 @@ public class UserController {
     )
     public ResponseEntity<UserDTO> createUser(@RequestBody UserRegisterDTO userRegisterDTO) throws ResourceAlreadyExistsException, ResourceNotFoundException {
         return new ResponseEntity<>(userService.create(userRegisterDTO), HttpStatus.CREATED);
+    }
+
+    @GetMapping
+    @ApiOperation(value = "Get user by token", notes = "Returns the user", authorizations = {@Authorization(value = "JWT Token")})
+    public ResponseEntity<UserDTO> getUser(HttpServletRequest request) throws ResourceNotFoundException {
+        String token = request.getHeader("Authorization");
+        if (token == null ) return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+        String jwt = token.substring(7);
+        String email = jwtUtil.extractUsername(jwt);
+        UserDTO user = userService.findByEmail(email);
+        return new ResponseEntity<>(user, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/mercadolibro/dto/AuthReq.java
+++ b/src/main/java/com/mercadolibro/dto/AuthReq.java
@@ -1,0 +1,9 @@
+package com.mercadolibro.dto;
+
+import lombok.Data;
+
+@Data
+public class AuthReq {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/mercadolibro/dto/AuthReq.java
+++ b/src/main/java/com/mercadolibro/dto/AuthReq.java
@@ -1,9 +1,12 @@
 package com.mercadolibro.dto;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
 @Data
 public class AuthReq {
+    @ApiModelProperty(value = "Email of the user", required = true, example = "juan@example.com")
     private String email;
+    @ApiModelProperty(value = "Password of the user", required = true, example = "123456")
     private String password;
 }

--- a/src/main/java/com/mercadolibro/dto/AuthResp.java
+++ b/src/main/java/com/mercadolibro/dto/AuthResp.java
@@ -1,0 +1,11 @@
+package com.mercadolibro.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class AuthResp {
+    private String token;
+    private UserDTO user;
+}

--- a/src/main/java/com/mercadolibro/dto/AuthResp.java
+++ b/src/main/java/com/mercadolibro/dto/AuthResp.java
@@ -1,11 +1,14 @@
 package com.mercadolibro.dto;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
 @AllArgsConstructor
 public class AuthResp {
+    @ApiModelProperty(value = "Token of the user", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJqdWFuQGV4YW1wbGUuY29tIiwicm9sZXMiOlsiUk9MRV9VU0")
     private String token;
+    @ApiModelProperty(value = "User")
     private UserDTO user;
 }

--- a/src/main/java/com/mercadolibro/entity/AppUser.java
+++ b/src/main/java/com/mercadolibro/entity/AppUser.java
@@ -45,7 +45,7 @@ public class AppUser {
     @Column(name = "date_created")
     LocalDateTime dateCreated;
 
-    @ManyToMany(fetch = FetchType.LAZY)
+    @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(
             name = "user_role",
             joinColumns = @JoinColumn(name = "user_id"),

--- a/src/main/java/com/mercadolibro/repository/AppUserRepository.java
+++ b/src/main/java/com/mercadolibro/repository/AppUserRepository.java
@@ -3,6 +3,9 @@ package com.mercadolibro.repository;
 import com.mercadolibro.entity.AppUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface AppUserRepository extends JpaRepository<AppUser, Integer> {
     boolean existsByEmail(String email);
+    Optional<AppUser> findByEmail(String email);
 }

--- a/src/main/java/com/mercadolibro/security/Encoder.java
+++ b/src/main/java/com/mercadolibro/security/Encoder.java
@@ -1,0 +1,13 @@
+package com.mercadolibro.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class Encoder {
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/mercadolibro/security/JwtFilter.java
+++ b/src/main/java/com/mercadolibro/security/JwtFilter.java
@@ -1,0 +1,52 @@
+package com.mercadolibro.security;
+
+import com.mercadolibro.service.UserService;
+import com.mercadolibro.util.JwtUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtFilter extends OncePerRequestFilter {
+    private final UserService userService;
+
+    private final JwtUtil jwtUtil;
+
+    @Autowired
+    public JwtFilter(UserService userService, JwtUtil jwtUtil) {
+        this.userService = userService;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String authorizationHeader = request.getHeader("Authorization");
+
+        if(authorizationHeader != null && authorizationHeader.startsWith("Bearer")) {
+            String jwt = authorizationHeader.substring(7);
+            String username = jwtUtil.  extractUsername(jwt);
+
+            if(username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                UserDetails userDetails = userService.loadUserByUsername(username);
+                if (jwtUtil.validateToken(jwt, userDetails)) {
+                    UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(userDetails, null ,userDetails.getAuthorities());
+                    authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+                    SecurityContextHolder.getContext().setAuthentication(authToken);
+                }
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/mercadolibro/security/SecurityConfig.java
+++ b/src/main/java/com/mercadolibro/security/SecurityConfig.java
@@ -1,0 +1,17 @@
+package com.mercadolibro.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.authorizeHttpRequests(auth -> {
+            auth.antMatchers("/**").permitAll();
+        });
+        return http.build();
+    }
+}

--- a/src/main/java/com/mercadolibro/security/SecurityConfig.java
+++ b/src/main/java/com/mercadolibro/security/SecurityConfig.java
@@ -1,17 +1,50 @@
 package com.mercadolibro.security;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 public class SecurityConfig {
+    private final UserDetailsService userDetailsService;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtFilter jwtFilter;
+
+    @Autowired
+    public SecurityConfig(UserDetailsService userDetailsService, PasswordEncoder passwordEncoder, JwtFilter jwtFilter) {
+        this.userDetailsService = userDetailsService;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtFilter = jwtFilter;
+    }
+
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.authorizeHttpRequests(auth -> {
             auth.antMatchers("/**").permitAll();
         });
+
+        http.formLogin().disable();
+        http.httpBasic().disable();
+        http.csrf().disable();
+        http.sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManagerBean(HttpSecurity http) throws Exception {
+        AuthenticationManagerBuilder authenticationManagerBuilder = http.getSharedObject(AuthenticationManagerBuilder.class);
+        authenticationManagerBuilder
+                .userDetailsService(userDetailsService)
+                .passwordEncoder(passwordEncoder);
+        return authenticationManagerBuilder.build();
     }
 }

--- a/src/main/java/com/mercadolibro/service/UserService.java
+++ b/src/main/java/com/mercadolibro/service/UserService.java
@@ -38,4 +38,13 @@ public interface UserService extends UserDetailsService {
     * @throws ResourceNotFoundException If one or more roles provided do not exist in the system.
      */
     UserDTO create(UserRegisterDTO userRegisterDTO) throws ResourceAlreadyExistsException, ResourceNotFoundException;
+
+    /**
+     * Finds a user by their email address.
+     * @param email The email address of the user to find.
+     * @return A UserDTO representing the user found.
+     * @throws ResourceNotFoundException If no user with the specified email address exists.
+     * @see UserDTO
+     */
+    UserDTO findByEmail(String email) throws ResourceNotFoundException;
 }

--- a/src/main/java/com/mercadolibro/service/UserService.java
+++ b/src/main/java/com/mercadolibro/service/UserService.java
@@ -4,10 +4,11 @@ import com.mercadolibro.exception.ResourceAlreadyExistsException;
 import com.mercadolibro.exception.ResourceNotFoundException;
 import com.mercadolibro.dto.UserDTO;
 import com.mercadolibro.dto.UserRegisterDTO;
+import org.springframework.security.core.userdetails.UserDetailsService;
 
 import java.util.List;
 
-public interface UserService {
+public interface UserService extends UserDetailsService {
 
     /**
      * Creates a new user based on the provided UserRegistrationDTO and assigns the specified roles to the user.

--- a/src/main/java/com/mercadolibro/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/mercadolibro/service/impl/UserServiceImpl.java
@@ -12,6 +12,9 @@ import com.mercadolibro.repository.AppUserRoleRepository;
 import com.mercadolibro.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -61,5 +64,14 @@ public class UserServiceImpl implements UserService {
         }
 
         return appUserRoles;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        AppUser appUser = appUserRepository.findByEmail(username).orElseThrow(() -> new UsernameNotFoundException("User " + username + " not found"));
+
+        return User.withUsername(appUser.getEmail())
+                .password(appUser.getPassword())
+                .roles(appUser.getRoles().stream().map(AppUserRole::getDescription).toArray(String[]::new)).build();
     }
 }

--- a/src/main/java/com/mercadolibro/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/mercadolibro/service/impl/UserServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -30,24 +31,26 @@ public class UserServiceImpl implements UserService {
     private final AppUserRepository appUserRepository;
     private final AppUserRoleRepository appUserRoleRepository;
     private final UserMapper userMapper;
+    private final PasswordEncoder passwordEncoder;
 
     @Autowired
-    public UserServiceImpl(AppUserRepository appUserRepository, AppUserRoleRepository appUserRoleRepository, @Value("${app.user.default-roles}") List<String> defaultRoles, UserMapper userMapper) {
+    public UserServiceImpl(AppUserRepository appUserRepository, AppUserRoleRepository appUserRoleRepository, @Value("${app.user.default-roles}") List<String> defaultRoles, UserMapper userMapper, PasswordEncoder passwordEncoder) {
         this.appUserRepository = appUserRepository;
         this.appUserRoleRepository = appUserRoleRepository;
         this.defaultRoles = defaultRoles;
         this.userMapper = userMapper;
+        this.passwordEncoder = passwordEncoder;
     }
 
     @Override
     public UserDTO create(UserRegisterDTO userRegisterDTO, List<String> roles) throws ResourceAlreadyExistsException, ResourceNotFoundException {
-        //TODO encrypt password
         if (appUserRepository.existsByEmail(userRegisterDTO.getEmail())) throw new ResourceAlreadyExistsException("User already exists");
 
         AppUser appUser = userMapper.toAppUser(userRegisterDTO);
         appUser.setRoles(getRoles(roles));
         appUser.setStatus("ACTIVE");
         appUser.setDateCreated(LocalDateTime.now());
+        appUser.setPassword(passwordEncoder.encode(appUser.getPassword()));
 
         return userMapper.toUserDTO(appUserRepository.save(appUser));
     }
@@ -55,6 +58,11 @@ public class UserServiceImpl implements UserService {
     @Override
     public UserDTO create(UserRegisterDTO userRegisterDTO) throws ResourceAlreadyExistsException, ResourceNotFoundException {
         return create(userRegisterDTO, defaultRoles);
+    }
+
+    @Override
+    public UserDTO findByEmail(String email) throws ResourceNotFoundException {
+        return userMapper.toUserDTO(appUserRepository.findByEmail(email).orElseThrow(() -> new ResourceNotFoundException("User " + email + " not found")));
     }
 
     private List<AppUserRole> getRoles(List<String> roles) throws ResourceNotFoundException {

--- a/src/main/java/com/mercadolibro/util/JwtUtil.java
+++ b/src/main/java/com/mercadolibro/util/JwtUtil.java
@@ -16,9 +16,9 @@ public class JwtUtil {
     private final String secret;
     private final int expirationInSeconds;
 
-    public JwtUtil(/*@Value("${app.jwt.secret}") String secret, @Value("${app.jwt.expiration}") int expirationInSeconds/*/) {
-        this.secret = "secret";
-        this.expirationInSeconds = 10000;
+    public JwtUtil(@Value("${app.jwt.secret}") String secret, @Value("${app.jwt.expiration}") int expirationInSeconds) {
+        this.secret = secret;
+        this.expirationInSeconds = expirationInSeconds;
     }
 
     public String generateToken(AppUser appUser) {

--- a/src/main/java/com/mercadolibro/util/JwtUtil.java
+++ b/src/main/java/com/mercadolibro/util/JwtUtil.java
@@ -1,0 +1,57 @@
+package com.mercadolibro.util;
+
+import com.mercadolibro.dto.UserDTO;
+import com.mercadolibro.entity.AppUser;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+    private final String secret;
+    private final int expirationInSeconds;
+
+    public JwtUtil(/*@Value("${app.jwt.secret}") String secret, @Value("${app.jwt.expiration}") int expirationInSeconds/*/) {
+        this.secret = "secret";
+        this.expirationInSeconds = 10000;
+    }
+
+    public String generateToken(AppUser appUser) {
+        return Jwts.builder()
+                .setSubject(appUser.getEmail())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + expirationInSeconds * 1000L))
+                .signWith(SignatureAlgorithm.HS256, secret)
+                .compact();
+    }
+
+    public String generateToken(UserDTO userDTO) {
+        return Jwts.builder()
+                .setSubject(userDTO.getEmail())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + expirationInSeconds * 1000L))
+                .signWith(SignatureAlgorithm.HS256, secret)
+                .compact();
+    }
+
+    public boolean validateToken(String token, UserDetails userDetails){
+        return userDetails.getUsername().equals(extractUsername(token)) && !isTokenExpired(token);
+    }
+
+    public String extractUsername(String token) {
+        return getClaims(token).getSubject();
+    }
+
+    public boolean isTokenExpired(String token) {
+        return getClaims(token).getExpiration().before(new Date());
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parser().setSigningKey(secret).parseClaimsJws(token).getBody();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,9 @@ app:
   roles: ${ROLES:ADMIN,USER}
   user:
     default-roles: USER
+  jwt:
+    secret: ${JWT_SECRET:secret}
+    expiration: ${JWT_EXPIRATION:86400}
 
 spring:
   jpa:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -3,6 +3,9 @@ app:
   roles: ${ROLES:ADMIN,USER}
   user:
     default-roles: USER
+  jwt:
+    secret: ${JWT_SECRET:secret}
+    expiration: ${JWT_EXPIRATION:86400}
 
 spring:
   datasource:


### PR DESCRIPTION
## Resumen
Se agregaron los endpoints /auth/login, /auth/refresh y se agregó un método get a /user . Ver swagger
Se implementó el password encoder (por lo cual registros antiguos de la base de datos deberían dejar de funcionar)
Se agregó spring security con una configuración que permite que cualquier usuario sin autenticación acceda a todos los endpoints menos aquellos que por su implementación requieren de un usuario autenticado (/auth/refresh o /user)
Se agregaron las variables de entorno JWT_SECRET y JWT_EXPIRATION para configurar en producción el secret y el tiempo de expiración de los tokens en segundos. Los valores por defecto son secret y 86400 respectivamente.
Relacionado con:
- [ML-11](https://mercado-libro.atlassian.net/browse/ML-11rl)

## Funcionamiento
### Login
Para hacer login se deb enviar una petición POST al endpoint `/v1/api/auth/login` con el body:
```JSON
{
  "email": "string",
  "password": "string"
}
```
y se recibirá una respuesta en el siguiente formato:
```JSON
{
  "token": "string",
  "user": {
    "dateCreated": "2023-10-31T18:18:47.264Z",
    "email": "juan@example.com",
    "id": 1,
    "lastName": "Gutierrez",
    "name": "Juan",
    "roles": [
      {
        "description": "ADMIN",
        "id": 1,
        "status": "ACTIVE"
      }
    ],
    "status": "ACTIVE"
  }
}
```

Al obtener el token se puede agregarlo a swagger para que lo utilicé en las operaciones que lo requieren haciendo clic aquí:
![image](https://github.com/jhavierc/mercado-libro-backend/assets/62969028/703df81d-979c-40bb-85f0-3d89027c72cb)

Se ingresa el token y se da clic en authorize
![image](https://github.com/jhavierc/mercado-libro-backend/assets/62969028/ab6af3ed-42d4-4fce-bb54-5520188ec11a)

Luego swagger se encargará de agregar el token al header de las peticiones que requieran autenticación

### Refresh token
Para obtener un nuevo token jwt se debe realizar una get request a:
`/v1/api/auth/refresh`  . Es importante que se envíe el header Authorization con el formato `Bearer TOKEN`
La respuesta se da siguiendo el mismo formato que en login
### GET /v1/api/user
Para hacer esta petición es necesario agregar el header de autorización. 
La respuesta seguirá el siguiente formato:
```JSON
{
  "dateCreated": "2023-10-31T18:26:31.908Z",
  "email": "juan@example.com",
  "id": 1,
  "lastName": "Gutierrez",
  "name": "Juan",
  "roles": [
    {
      "description": "ADMIN",
      "id": 1,
      "status": "ACTIVE"
    }
  ],
  "status": "ACTIVE"
}
```

## Tipo de cambio

- [x] Nueva característica (cambio que no rompe nada y agrega funcionalidad)
- [x] Cambio disruptivo (corrección o característica que causaría que la funcionalidad existente no funcione como se esperaba)

## Pruebas Unitarias
Se realizaron pruebas unitarias solamente en el user service . En cuanto a JwtUtil no realicé pruebas unitarias porque la gran mayoría del código es simplemente llamar a la librería `io.jsonwebtoken` .
Las pruebas unitarias agregadas a user service son:
- shouldFindUserByEmail
- findUserByEmailShouldThrowResourceNotFoundExceptionWhenUserDoesNotExist
- loadUserByUsernameShouldReturnUserDetails
- loadUserByUsernameShouldThrowUsernameNotFoundExceptionWhenUserDoesNotExist
# Lista de verificación:

- [x] Mi código sigue las pautas de estilo de este proyecto
- [x] Este cambio requiere una actualización de la documentación
- [x] He realizado cambios correspondientes en la documentación
