### PR TITLE
Feature/user list

### DIFF
--- a/src/main/java/com/mercadolibro/controller/UserController.java
+++ b/src/main/java/com/mercadolibro/controller/UserController.java
@@ -86,8 +86,8 @@ public class UserController {
     @ApiOperation(value = "Get all users", notes = "Returns all users")
     public ResponseEntity<PageDTO<UserDTO>> getAllUsers(
             @ModelAttribute UserQuery userQuery,
-            @RequestParam @Positive Integer page,
-            @RequestParam @Positive Integer size
+            @RequestParam(defaultValue = "0") @Positive Integer page,
+            @RequestParam(defaultValue = "10") @Positive Integer size
     ) {
         return new ResponseEntity<>(userService.find(userQuery, page, size), HttpStatus.OK);
     }

--- a/src/main/java/com/mercadolibro/controller/UserController.java
+++ b/src/main/java/com/mercadolibro/controller/UserController.java
@@ -1,24 +1,22 @@
 package com.mercadolibro.controller;
 
-import com.mercadolibro.dto.UserUpdateDTO;
+import com.mercadolibro.dto.*;
 import com.mercadolibro.entity.AppUserRole;
 import com.mercadolibro.exception.ResourceAlreadyExistsException;
 import com.mercadolibro.exception.ResourceNotFoundException;
-import com.mercadolibro.dto.UserDTO;
-import com.mercadolibro.dto.UserRegisterDTO;
 import com.mercadolibro.service.UserService;
 import com.mercadolibro.util.JwtUtil;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
-import io.swagger.v3.oas.annotations.headers.Header;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.constraints.Positive;
 import java.util.List;
 
 @RestController
@@ -86,13 +84,12 @@ public class UserController {
 
     @GetMapping
     @ApiOperation(value = "Get all users", notes = "Returns all users")
-    @ApiResponses(
-            value = {
-                    @ApiResponse(code = 200, message = "Users found", response = UserDTO.class, responseContainer = "List")
-            }
-    )
-    public ResponseEntity<List<UserDTO>> getAllUsers() {
-        return new ResponseEntity<>(userService.findAll(), HttpStatus.OK);
+    public ResponseEntity<PageDTO<UserDTO>> getAllUsers(
+            @ModelAttribute UserQuery userQuery,
+            @RequestParam @Positive Integer page,
+            @RequestParam @Positive Integer size
+    ) {
+        return new ResponseEntity<>(userService.find(userQuery, page, size), HttpStatus.OK);
     }
 
     @PatchMapping("/{id}")

--- a/src/main/java/com/mercadolibro/dto/PageDTO.java
+++ b/src/main/java/com/mercadolibro/dto/PageDTO.java
@@ -1,0 +1,31 @@
+package com.mercadolibro.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@ApiModel(description = "Model for a page of elements", value = "Page")
+public class PageDTO <DTO>{
+
+    @ApiModelProperty(value = "List of elements", required = true)
+    List<DTO> content;
+    @ApiModelProperty(value = "Total pages", required = true)
+    Integer totalPages;
+    @ApiModelProperty(value = "Total elements", required = true)
+    Long totalElements;
+    @ApiModelProperty(value = "Current page", required = true)
+    Integer currentPage;
+    @ApiModelProperty(value = "Page size", required = true)
+    Integer pageSize;
+
+    public PageDTO(List<DTO> contet, Integer totalPages, Long totalElements, Integer currentPage, Integer pageSize) {
+        this.content = contet;
+        this.totalPages = totalPages;
+        this.totalElements = totalElements;
+        this.currentPage = currentPage;
+        this.pageSize = pageSize;
+    }
+}

--- a/src/main/java/com/mercadolibro/dto/UserQuery.java
+++ b/src/main/java/com/mercadolibro/dto/UserQuery.java
@@ -1,0 +1,52 @@
+package com.mercadolibro.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+import org.springframework.data.domain.Sort;
+
+import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.Email;
+
+/**
+ * Model for make a query to the user
+ * Each field is optional, so you can make a query with only one field or with all of them
+ * If you don't specify the orderDirection or orderBy, the default values are ASC and ID respectively
+ *
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(description = "Model for make a query to the user", value = "UserQuery")
+@Builder
+public class UserQuery {
+    @ApiModelProperty(value = "Name of the user", required = false, example = "Juan")
+    String name;
+    @ApiModelProperty(value = "Last name of the user", required = false, example = "Gutierrez")
+    String lastName;
+    @ApiModelProperty(value = "Email of the user", required = false, example = "juan@example.com")
+    @Email
+    String email;
+    @ApiModelProperty(value = "Status of the user", required = false, example = "ACTIVE")
+    String status;
+    @ApiModelProperty(value = "Direction of the sort", required = false, example = "ASC", notes = "Only ASC or DESC are valid values")
+    Sort.Direction orderDirection = Sort.Direction.ASC;
+    @ApiModelProperty(value = "Order by of the user", required = false, example = "NAME", notes = "Only ID, NAME, LAST_NAME, EMAIL or STATUS are valid values")
+    OrderBy orderBy = OrderBy.ID;
+
+    @Getter
+    public enum OrderBy {
+        ID("id"), NAME("name"), LAST_NAME("lastName"), EMAIL("email"), STATUS("status");
+
+        private String value;
+
+        OrderBy(String value) {
+            this.value = value;
+        }
+
+
+    }
+
+
+}
+

--- a/src/main/java/com/mercadolibro/entity/AppUser.java
+++ b/src/main/java/com/mercadolibro/entity/AppUser.java
@@ -1,6 +1,7 @@
 package com.mercadolibro.entity;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -17,6 +18,7 @@ import java.util.List;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class AppUser {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/mercadolibro/service/UserService.java
+++ b/src/main/java/com/mercadolibro/service/UserService.java
@@ -1,11 +1,10 @@
 package com.mercadolibro.service;
 
-import com.mercadolibro.dto.UserUpdateDTO;
+import com.mercadolibro.dto.*;
 import com.mercadolibro.entity.AppUserRole;
 import com.mercadolibro.exception.ResourceAlreadyExistsException;
 import com.mercadolibro.exception.ResourceNotFoundException;
-import com.mercadolibro.dto.UserDTO;
-import com.mercadolibro.dto.UserRegisterDTO;
+import org.springframework.data.domain.Page;
 import org.springframework.security.core.userdetails.UserDetailsService;
 
 import java.util.List;
@@ -79,5 +78,13 @@ public interface UserService extends UserDetailsService {
      * @throws ResourceNotFoundException If one or more roles provided do not exist in the system.
      */
     UserDTO update(UserUpdateDTO userUpdateDTO, Integer userId) throws ResourceNotFoundException;
+
+    /**
+     * Find users by query
+     * @param userQuery The query to filter users. It can be null to get all users.
+     * @param page The page number
+     * @return A page of users
+     */
+    PageDTO<UserDTO> find(UserQuery userQuery, Integer page, Integer size);
 
 }

--- a/src/main/java/com/mercadolibro/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/mercadolibro/service/impl/UserServiceImpl.java
@@ -20,12 +20,14 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@Transactional
 public class UserServiceImpl implements UserService {
     /* Variables */
     private final List<String> defaultRoles;

--- a/src/test/java/com/mercadolibro/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/mercadolibro/service/impl/UserServiceImplTest.java
@@ -356,4 +356,29 @@ class UserServiceImplTest {
         verify(userRepository, never()).save(any(AppUser.class));
         verify(userRoleRepository, atLeast(1)).findByDescription("ADMIN");
     }
+
+    @Test
+    void findShouldReturnAllUsers() {
+        // GIVEN
+        AppUser user = users.get(0);
+
+        //WHEN
+        when(userRepository.findAll()).thenReturn(users);
+
+        List<UserDTO> usersFound = userService.findAll();
+
+        // THEN
+        assertNotNull(usersFound);
+        assertEquals(1, usersFound.size());
+        assertEquals(user.getName(), usersFound.get(0).getName());
+        assertEquals(user.getLastName(), usersFound.get(0).getLastName());
+        assertEquals(user.getEmail(), usersFound.get(0).getEmail());
+        assertEquals(user.getRoles().get(0).getDescription(), usersFound.get(0).getRoles().get(0).getDescription());
+        assertEquals(user.getId(), usersFound.get(0).getId());
+        assertEquals(user.getStatus(), usersFound.get(0).getStatus());
+        assertEquals(user.getDateCreated(), usersFound.get(0).getDateCreated());
+        verify(userRepository, times(1)).findAll();
+    }
+
+
 }


### PR DESCRIPTION
## Resumen
Se agregó paginación al método GET de /user . Además se agregaron varios filtros y opciones de ordenamiento.

Relacionado con:
- [ML-265](https://mercado-libro.atlassian.net/browse/ML-265)

## Funcionamiento
![image](https://github.com/jhavierc/mercado-libro-backend/assets/62969028/296cdb93-49d9-4242-9e5e-ddb95e6129ba)
Por query params se le pueden pasar los parámetros que se ven en la imágen. Si no se indica valor para page y size se asignarán por defecto la página 0 y tamaño 10. 

La respuesta del endpoint es en este formato: 
```JSON
{
  "content": [
    {
      "dateCreated": "2023-11-04T00:02:45.618Z",
      "email": "juan@example.com",
      "id": 1,
      "lastName": "Gutierrez",
      "name": "Juan",
      "roles": [
        {
          "description": "ADMIN",
          "id": 1,
          "status": "ACTIVE"
        }
      ],
      "status": "ACTIVE"
    }
  ],
  "currentPage": 0,
  "pageSize": 0,
  "totalElements": 0,
  "totalPages": 0
}
```

## Tipo de cambio
[Eliminar las opciones que no sean relevantes]
- [x] Cambio disruptivo (corrección o característica que causaría que la funcionalidad existente no funcione como se esperaba)

## Pruebas Unitarias
Se realizaron pruebas unitarias para verificar el funcionamiento elemental del método find del service.
Intenté buscar una manera de testear más casos, pero había que mockear demasiadas, me pareció más apropiado testear en las pruebas de integración ya que el correcto funcionamiento de los filtros depende más de la configuración de JPA que de la lógica del servicio

# Lista de verificación:

- [x] Mi código sigue las pautas de estilo de este proyecto
- [x] Este cambio requiere una actualización de la documentación
- [x] He realizado cambios correspondientes en la documentación
