### PR TITLE
Hotfix/Mercadopago preference ID

### DIFF
--- a/src/main/java/com/mercadolibro/config/MercadoPagoConfig.java
+++ b/src/main/java/com/mercadolibro/config/MercadoPagoConfig.java
@@ -8,10 +8,29 @@ import org.springframework.context.annotation.Configuration;
 public class MercadoPagoConfig {
     @Value("${app.mercadopago.access-token}")
     private String mercadoPagoAccessToken;
+    @Value("${app.mercadopago.preference.back-urls.success}")
+    private String mercadoPagoPreferenceBackUrlSuccess;
+    @Value("${app.mercadopago.preference.back-urls.pending}")
+    private String mercadoPagoPreferenceBackUrlPending;
+    @Value("${app.mercadopago.preference.back-urls.failure}")
+    private String mercadoPagoPreferenceBackUrlFailure;
+
 
     @Bean
     public String mercadoPagoAccessToken() {
         return mercadoPagoAccessToken;
+    }
+    @Bean
+    public String mercadoPagoPreferenceBackUrlSuccess() {
+        return mercadoPagoPreferenceBackUrlSuccess;
+    }
+    @Bean
+    public String mercadoPagoPreferenceBackUrlPending() {
+        return mercadoPagoPreferenceBackUrlPending;
+    }
+    @Bean
+    public String mercadoPagoPreferenceBackUrlFailure() {
+        return mercadoPagoPreferenceBackUrlFailure;
     }
 
 }

--- a/src/main/java/com/mercadolibro/dto/InvoiceDTO.java
+++ b/src/main/java/com/mercadolibro/dto/InvoiceDTO.java
@@ -62,4 +62,7 @@ public class InvoiceDTO {
 
     @JsonProperty("payment_method")
     private PaymentMethod paymentMethod;
+
+    @JsonProperty("preference_id")
+    private String preferenceId;
 }

--- a/src/main/java/com/mercadolibro/service/impl/InvoiceRequestServiceImpl.java
+++ b/src/main/java/com/mercadolibro/service/impl/InvoiceRequestServiceImpl.java
@@ -270,7 +270,7 @@ public class InvoiceRequestServiceImpl implements InvoiceRequestService {
 
             PreferenceBackUrlsRequest backUrls =
                     PreferenceBackUrlsRequest.builder()
-                            .success("http://localhost:5173/success")
+                            .success("http://localhost:5173/successful")
                             .pending("http://localhost:5173/pending")
                             .failure("http://localhost:5173/failure")
                             .build();

--- a/src/main/java/com/mercadolibro/service/impl/InvoiceRequestServiceImpl.java
+++ b/src/main/java/com/mercadolibro/service/impl/InvoiceRequestServiceImpl.java
@@ -43,6 +43,9 @@ public class InvoiceRequestServiceImpl implements InvoiceRequestService {
     private final InvoiceItemRepository invoiceItemRepository;
     private final ObjectMapper mapper;
     private final String mercadoPagoAccessToken;
+    private final String mercadoPagoPreferenceBackUrlSuccess;
+    private final String mercadoPagoPreferenceBackUrlPending;
+    private final String mercadoPagoPreferenceBackUrlFailure;
     private final BookRepository bookRepository;
     private final BookService bookService;
     private final UserService userService;
@@ -53,11 +56,14 @@ public class InvoiceRequestServiceImpl implements InvoiceRequestService {
     public static final String INVOICE_NOT_FOUND = "Invoice with ID '%s' not found";
 
 
-    public InvoiceRequestServiceImpl(InvoiceRepository invoiceRepository, InvoiceItemRepository invoiceItemRepository, ObjectMapper mapper, String mercadoPagoAccessToken, BookRepository bookRepository, BookService bookService, UserService userService) {
+    public InvoiceRequestServiceImpl(InvoiceRepository invoiceRepository, InvoiceItemRepository invoiceItemRepository, ObjectMapper mapper, String mercadoPagoAccessToken, String mercadoPagoPreferenceBackUrlSuccess, String mercadoPagoPreferenceBackUrlPending, String mercadoPagoPreferenceBackUrlFailure, BookRepository bookRepository, BookService bookService, UserService userService) {
         this.invoiceRepository = invoiceRepository;
         this.invoiceItemRepository = invoiceItemRepository;
         this.mapper = mapper;
         this.mercadoPagoAccessToken = mercadoPagoAccessToken;
+        this.mercadoPagoPreferenceBackUrlSuccess = mercadoPagoPreferenceBackUrlSuccess;
+        this.mercadoPagoPreferenceBackUrlPending = mercadoPagoPreferenceBackUrlPending;
+        this.mercadoPagoPreferenceBackUrlFailure = mercadoPagoPreferenceBackUrlFailure;
         this.bookRepository = bookRepository;
         this.bookService = bookService;
         this.userService = userService;
@@ -270,9 +276,9 @@ public class InvoiceRequestServiceImpl implements InvoiceRequestService {
 
             PreferenceBackUrlsRequest backUrls =
                     PreferenceBackUrlsRequest.builder()
-                            .success("http://localhost:5173/successful")
-                            .pending("http://localhost:5173/pending")
-                            .failure("http://localhost:5173/failure")
+                            .success(mercadoPagoPreferenceBackUrlSuccess)
+                            .pending(mercadoPagoPreferenceBackUrlPending)
+                            .failure(mercadoPagoPreferenceBackUrlFailure)
                             .build();
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,11 @@ app:
         scope: ${OAUTH_SCOPE:openid}
   mercadopago:
     access-token: ${MERCADOPAGO_ACCESS_TOKEN}
+    preference:
+      back-urls:
+        success: ${MERCADOPAGO_PREFERENCE_BACK_URLS_SUCCESS:http://localhost:5173/successful}
+        pending: ${MERCADOPAGO_PREFERENCE_BACK_URLS_PENDING:http://localhost:5173/pending}
+        failure: ${MERCADOPAGO_PREFERENCE_BACK_URLS_FAILURE:http://localhost:5173/failure}
 
 spring:
   jpa:


### PR DESCRIPTION
## Resumen
Se agregó la generación del campo `preference_id` a través de la SDK de MercadoPago en el backend.

Relacionado con:
- [ML-310](https://mercado-libro.atlassian.net/browse/ML-310)

## Funcionamiento
El campo solo puede ser obtenido al momento de crear una invoice.

Ejemplo de la nueva respuesta recibida a la hora de crear invoices:
```json
{
    "invoice": {
        "id": "5eaf42ef-7fdf-440b-951e-e16c5ffcb15f",
        "date_created": "2023-11-30",
        "total": 17280.0,
        "tax": 0.0,
        "user_id": 2,
        "bank": "Banco",
        "account_number": "4838475834930",
        "address": "Calle 1234, Buenos Aires, Argentina",
        "deadline": "LLega el martes 17 a la noche",
        "cardholder": "Pedro",
        "expiration_date": "12/25",
        "dni": 12345678,
        "document_type": "DNI",
        "card_number": "4230-3452-7243-4442",
        "notes": "No funciona el timbre",
        "paid": false,
        "payment_method": "MERCADO_PAGO",
        "preference_id": "250081001-0be4e3e9-ca63-43a7-80e0-056c4fe69f1f"
    },
    "invoice_item": [
        {
            "id": 10,
            "book_id": 22,
            "unit_price": 17280.0,
            "quantity": 1,
            "total": 17280.0,
            "invoice_id": "5eaf42ef-7fdf-440b-951e-e16c5ffcb15f"
        }
    ]
}
``` 

Si el usuario es dirigido al checkout nativo de MercadoPago, el campo `preference_id` está configurado para que una vez terminado el flujo sea redireccionado a las siguientes URLs de nuestro frontend:
- Success: http://localhost:5173/successful
- Pending: http://localhost:5173/pending
- Failure: http://localhost:5173/failure
                            
Si es necesario es posible cambiar estas URLs a través de las siguientes variables del backend:

- Success: `MERCADOPAGO_PREFERENCE_BACK_URLS_SUCCESS`
- Pending: `MERCADOPAGO_PREFERENCE_BACK_URLS_PENDING`
- Failure: `MERCADOPAGO_PREFERENCE_BACK_URLS_FAILURE`

## Tipo de cambio
[Eliminar las opciones que no sean relevantes]

- [ ] Corrección de error (cambio que no rompe nada y resuelve un problema)
- [X] Nueva característica (cambio que no rompe nada y agrega funcionalidad)
- [ ] Cambio disruptivo (corrección o característica que causaría que la funcionalidad existente no funcione como se esperaba)

# Lista de verificación:

- [X] Mi código sigue las pautas de estilo de este proyecto
- [X] Este cambio requiere una actualización de la documentación
- [X] He realizado cambios correspondientes en la documentación
